### PR TITLE
Fix README and INTEGRATION_GUIDE

### DIFF
--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -110,21 +110,25 @@ The `<origin>` block inside the macro call defines where the camera is mounted r
 - `xyz`: Position offset in meters (forward, left, up)
 - `rpy`: Orientation in radians (roll, pitch, yaw)
 
-## ROS Topics Published
+## ROS2 Topics Published
 
-When integrated, the L515 sensor will publish to the following topics (assuming `topics_ns="camera"`):
+When integrated, the L515 sensor publishes the following ROS2 topics
+(assuming `topics_ns="camera"`):
 
-**For ROS 1:**
-- `/camera/color/image_raw` - RGB color image
-- `/camera/color/camera_info` - Color camera calibration
-- `/camera/depth/image_rect_raw` - Depth image
-- `/camera/depth/camera_info` - Depth camera calibration
-- `/camera/infra/image_raw` - Infrared image
-- `/camera/infra/camera_info` - Infrared camera calibration
-- `/camera/depth/color/points` - Point cloud (if enabled)
+| Topic | Type | Notes |
+|-------|------|-------|
+| `/camera/color/image_raw` | `sensor_msgs/Image` | 1920×1080 RGB |
+| `/camera/color/camera_info` | `sensor_msgs/CameraInfo` | |
+| `/camera/depth/image_raw` | `sensor_msgs/Image` | Float32 depth map |
+| `/camera/depth/camera_info` | `sensor_msgs/CameraInfo` | |
+| `/camera/infra/image_raw` | `sensor_msgs/Image` | Grayscale |
+| `/camera/infra/camera_info` | `sensor_msgs/CameraInfo` | |
+| `/camera/depth/color/points` | `sensor_msgs/PointCloud2` | Requires `publish_pointcloud="true"` |
 
-**For ROS 2:**
-Same topic names, accessed via `ros2 topic list`
+> **Bridge requirement:** topics are delivered to ROS2 via `ros_gz_image` and `ros_gz_bridge`.
+> The bridge arguments in your launch file must match the `topics_ns` you choose.
+> If you use `topics_ns="front_camera"`, bridge `/front_camera/color`,
+> `/front_camera/depth`, `/front_camera/depth/points`, etc.
 
 ## Common Integration Examples
 

--- a/README.md
+++ b/README.md
@@ -129,9 +129,11 @@ sudo apt install -y \
 ```bash
 mkdir -p ~/ros2_ws/src
 cd ~/ros2_ws/src
-git clone https://github.com/ZohebAbai/gazebo_ros_l515.git
+git clone -b update/2025-jazzy-harmonic-port https://github.com/ZohebAbai/gazebo_ros_l515.git
 cd ~/ros2_ws
 ```
+
+> Once PR #5 is merged into `main`, drop the `-b update/2025-jazzy-harmonic-port` flag.
 
 ### 5. Build
 
@@ -259,10 +261,10 @@ Expected topics:
 
 Check data rates:
 ```bash
-# Color image — expect ~30 Hz
+# Color image — expect ~10-30 Hz (depends on GPU/CPU performance)
 ros2 topic hz /camera/color/image_raw
 
-# Point cloud — expect ~30 Hz
+# Point cloud — expect ~10-30 Hz
 ros2 topic hz /camera/depth/color/points
 
 # Print one camera_info message
@@ -289,8 +291,24 @@ Include the L515 macro in your URDF/xacro:
 </xacro:sensor_l515>
 ```
 
-See [INTEGRATION_GUIDE.md](INTEGRATION_GUIDE.md) for the full parameter reference and example
-launch file.
+> **Note:** `topics_ns` sets the Gazebo sensor topic prefix and must match the bridge
+> configuration in your launch file. The default `"camera"` matches the provided launch files.
+> If you use a different namespace (e.g. `topics_ns="front_camera"`), update the
+> `ros_gz_image` and `ros_gz_bridge` arguments in your launch file to match
+> (e.g. `/front_camera/color`, `/front_camera/depth`, `/front_camera/depth/points`).
+
+**ROS2 topics published** (with `topics_ns="camera"`):
+
+| Topic | Type | Description |
+|-------|------|-------------|
+| `/camera/color/image_raw` | `sensor_msgs/Image` | 1920×1080 RGB image |
+| `/camera/depth/image_raw` | `sensor_msgs/Image` | Depth map |
+| `/camera/infra/image_raw` | `sensor_msgs/Image` | Infrared image |
+| `/camera/depth/color/points` | `sensor_msgs/PointCloud2` | Colored point cloud |
+| `/camera/*/camera_info` | `sensor_msgs/CameraInfo` | Calibration for each sensor |
+
+See [INTEGRATION_GUIDE.md](INTEGRATION_GUIDE.md) for the full parameter reference and
+multi-camera examples.
 
 ---
 


### PR DESCRIPTION
- Correct expected topic Hz from ~30 to ~10-30 (measured ~11 Hz on test hardware)
- Fix clone URL to point to PR branch until merged into main
- Add topics_ns bridge note to README integration section
- Add topic table with correct ROS2 topic names (image_raw not image_rect_raw)
- Remove ROS1 section from INTEGRATION_GUIDE (ROS1 unsupported)
- Add bridge requirement note for custom topics_ns in INTEGRATION_GUIDE