### PR TITLE
Fix duplicate aluminum material in mobile_robot URDF

### DIFF
--- a/realsense2_description/urdf/example_mobile_robot_with_l515.urdf.xacro
+++ b/realsense2_description/urdf/example_mobile_robot_with_l515.urdf.xacro
@@ -16,11 +16,11 @@ To use this example:
 
 <robot name="mobile_robot_with_l515" xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <!-- Include the L515 sensor macro -->
+  <!-- Include the L515 sensor macro. _l515.urdf.xacro already pulls in
+       _materials.urdf.xacro, so we must not include materials a second
+       time here — xacro has no include guard and a duplicate <material>
+       tag fails URDF parsing in robot_state_publisher. -->
   <xacro:include filename="$(find realsense2_description)/urdf/_l515.urdf.xacro" />
-
-  <!-- Include materials for visualization -->
-  <xacro:include filename="$(find realsense2_description)/urdf/_materials.urdf.xacro" />
 
   <!-- Constants for robot dimensions -->
   <xacro:property name="base_length" value="0.6" />


### PR DESCRIPTION
## Summary
- `_l515.urdf.xacro` already includes `_materials.urdf.xacro`, so re-including it from `example_mobile_robot_with_l515.urdf.xacro` produced two `<material name="aluminum">` tags.
- xacro does not deduplicate includes, and the URDF parser used by `robot_state_publisher` rejects the merged document with `material 'aluminum' is not unique` — `/robot_description` is never published and Gazebo cannot spawn the robot.
- Drop the redundant include and document why a second materials include is unsafe.

## Test plan
- [ ] `xacro example_mobile_robot_with_l515.urdf.xacro` expands without errors and contains exactly one `<material name="aluminum">`.
- [ ] In a downstream consumer (e.g. `sensei_robot`), `robot_state_publisher` starts and publishes `/robot_description` instead of dying with `Unable to initialize urdf::model from robot description`.
- [ ] Gazebo Harmonic spawns the robot and the L515 image/depth topics start flowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)